### PR TITLE
fixed the arclength inversion of parameters in the call

### DIFF
--- a/tests/test_arclength.py
+++ b/tests/test_arclength.py
@@ -224,7 +224,7 @@ def test_length_constraint():
 
     # Control points and curve
     CP = lstsq(M, F.T)[0]
-    arky_fixed = ArcLengthParametrizer(vs, CP, 10, 1)
+    arky_fixed = ArcLengthParametrizer(vs, CP, 1)
     CP_al_lf = np.asarray(arky_fixed.reparametrize())
     new_arky_fixed = ArcLengthParametrizer(vs, CP_al_lf)
     new_arky_fixed.reparametrize()
@@ -270,8 +270,8 @@ def test_more_length_constraints():
     CP2 = np.empty((CP.shape[0],2,CP.shape[1]))
     CP2[:,0,:] = CP
     CP2[:,1,:] = 2*CP
-    arky_fixed1 = ArcLengthParametrizer(vs, CP2, 10, 1)
-    arky_fixed2 = ArcLengthParametrizer(vs, CP2, 10, 2)
+    arky_fixed1 = ArcLengthParametrizer(vs, CP2, 1)
+    arky_fixed2 = ArcLengthParametrizer(vs, CP2, 2)
     CP_al_lf1 = np.asarray(arky_fixed1.reparametrize())
     CP_al_lf2 = np.asarray(arky_fixed2.reparametrize())
     new_arky_fixed1 = ArcLengthParametrizer(vs, CP_al_lf1)

--- a/utilities/arclength.py
+++ b/utilities/arclength.py
@@ -15,10 +15,11 @@ class ArcLengthParametrizer(object):
     space dependent. If you have something time dependent you are asked to query
     this class time by time. We assume that the curve is parametrized from 0 to 1.
     """
-    def __init__(self, vector_space, init_control_points, arcfactor = 10,length_constraint = 0):
+    def __init__(self, vector_space, init_control_points,length_constraint = 0, arcfactor = 10):
 		"""The constructor needs an initital curve and we ask for a factor that we will use to 
 		numerically approximate the arclength, therefore we have called it arcfactor. We expect the
-		curve to be composed by a vector space and a control point array.
+		curve to be composed by a vector space and a control point array. The length_constraint 
+		specify the constraint on the curve length.
 		"""
 		self.all_init_control_points = np.asarray(init_control_points)
 		self.vector_space = AffineVectorSpace(vector_space)


### PR DESCRIPTION
I repeated the steps to invert "arcfactor" and "length_constraint" in order to make more natural the call of the reparametrizer. This time branching from master.