### PR TITLE
Modifications for to use scipy sparce matrices functions.

### DIFF
--- a/applications/MassMatrix.ipynb
+++ b/applications/MassMatrix.ipynb
@@ -18,12 +18,16 @@
       "from utilities import *\n",
       "import numpy as np\n",
       "#This command is for a prettier print of numpy arrays\n",
-      "np.set_printoptions(formatter={'float': '{: 0.3f}'.format})"
+      "np.set_printoptions(formatter={'float': '{: 0.3f}'.format})\n",
+      "\n",
+      "from scipy.sparse import *\n",
+      "import time\n",
+      "import matplotlib.pyplot as plt"
      ],
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 8
+     "prompt_number": 62
     },
     {
      "cell_type": "code",
@@ -61,7 +65,7 @@
        ]
       }
      ],
-     "prompt_number": 9
+     "prompt_number": 63
     },
     {
      "cell_type": "code",
@@ -76,13 +80,13 @@
       {
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 10,
+       "prompt_number": 64,
        "text": [
         "4"
        ]
       }
      ],
-     "prompt_number": 10
+     "prompt_number": 64
     },
     {
      "cell_type": "code",
@@ -97,19 +101,21 @@
       {
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 11,
+       "prompt_number": 65,
        "text": [
         "9"
        ]
       }
      ],
-     "prompt_number": 11
+     "prompt_number": 65
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "cum=np.zeros((nbasis,nbasis))\n",
+      "#test using sparce functions.\n",
+      "\n",
+      "cum=dok_matrix((nbasis,nbasis))\n",
       "(qst,wst)=np.polynomial.legendre.leggauss(5)      \n",
       "for lcell in xrange(vs.n_cells):\n",
       "    a,b=vs.cells[lcell],vs.cells[lcell+1]\n",
@@ -126,7 +132,13 @@
       "    for rout, rcum in zip(out, fnts):\n",
       "        for vout, ccum in zip(rout, fnts):\n",
       "            cum[rcum,ccum]+=vout\n",
-      "print cum, \"\\n\""
+      "            \n",
+      "#print using 3 formats\n",
+      "tmp=cum.todense()\n",
+      "print type(tmp), \"\\n\", tmp\n",
+      "tmp=cum.toarray()\n",
+      "print type(tmp), \"\\n\", tmp\n",
+      "print type(cum), \"\\n\", cum"
      ],
      "language": "python",
      "metadata": {},
@@ -135,6 +147,7 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
+        "<class 'numpy.matrixlib.defmatrix.matrix'> \n",
         "[[ 0.033  0.017 -0.008  0.000  0.000  0.000  0.000  0.000  0.000]\n",
         " [ 0.017  0.133  0.017  0.000  0.000  0.000  0.000  0.000  0.000]\n",
         " [-0.008  0.017  0.067  0.017 -0.008  0.000  0.000  0.000  0.000]\n",
@@ -143,17 +156,62 @@
         " [ 0.000  0.000  0.000  0.000  0.017  0.133  0.017  0.000  0.000]\n",
         " [ 0.000  0.000  0.000  0.000 -0.008  0.017  0.067  0.017 -0.008]\n",
         " [ 0.000  0.000  0.000  0.000  0.000  0.000  0.017  0.133  0.017]\n",
-        " [ 0.000  0.000  0.000  0.000  0.000  0.000 -0.008  0.017  0.033]] \n",
-        "\n"
+        " [ 0.000  0.000  0.000  0.000  0.000  0.000 -0.008  0.017  0.033]]\n",
+        "<type 'numpy.ndarray'> \n",
+        "[[ 0.033  0.017 -0.008  0.000  0.000  0.000  0.000  0.000  0.000]\n",
+        " [ 0.017  0.133  0.017  0.000  0.000  0.000  0.000  0.000  0.000]\n",
+        " [-0.008  0.017  0.067  0.017 -0.008  0.000  0.000  0.000  0.000]\n",
+        " [ 0.000  0.000  0.017  0.133  0.017  0.000  0.000  0.000  0.000]\n",
+        " [ 0.000  0.000 -0.008  0.017  0.067  0.017 -0.008  0.000  0.000]\n",
+        " [ 0.000  0.000  0.000  0.000  0.017  0.133  0.017  0.000  0.000]\n",
+        " [ 0.000  0.000  0.000  0.000 -0.008  0.017  0.067  0.017 -0.008]\n",
+        " [ 0.000  0.000  0.000  0.000  0.000  0.000  0.017  0.133  0.017]\n",
+        " [ 0.000  0.000  0.000  0.000  0.000  0.000 -0.008  0.017  0.033]]\n",
+        "<class 'scipy.sparse.dok.dok_matrix'> \n",
+        "  (6, 6)\t0.0666666666667\n",
+        "  (5, 6)\t0.0166666666667\n",
+        "  (5, 4)\t0.0166666666667\n",
+        "  (2, 1)\t0.0166666666667\n",
+        "  (1, 2)\t0.0166666666667\n",
+        "  (6, 7)\t0.0166666666667\n",
+        "  (3, 3)\t0.133333333333\n",
+        "  (7, 6)\t0.0166666666667\n",
+        "  (4, 4)\t0.0666666666667\n",
+        "  (2, 2)\t0.0666666666667\n",
+        "  (8, 6)\t-0.00833333333333\n",
+        "  (1, 1)\t0.133333333333\n",
+        "  (6, 4)\t-0.00833333333333\n",
+        "  (3, 2)\t0.0166666666667\n",
+        "  (0, 0)\t0.0333333333333\n",
+        "  (4, 5)\t0.0166666666667\n",
+        "  (7, 7)\t0.133333333333\n",
+        "  (2, 3)\t0.0166666666667\n",
+        "  (8, 7)\t0.0166666666667\n",
+        "  (6, 8)\t-0.00833333333333\n",
+        "  (4, 2)\t-0.00833333333333\n",
+        "  (1, 0)\t0.0166666666667\n",
+        "  (6, 5)\t0.0166666666667\n",
+        "  (5, 5)\t0.133333333333\n",
+        "  (0, 1)\t0.0166666666667\n",
+        "  (4, 6)\t-0.00833333333333\n",
+        "  (7, 8)\t0.0166666666667\n",
+        "  (0, 2)\t-0.00833333333333\n",
+        "  (2, 0)\t-0.00833333333333\n",
+        "  (8, 8)\t0.0333333333333\n",
+        "  (4, 3)\t0.0166666666667\n",
+        "  (3, 4)\t0.0166666666667\n",
+        "  (2, 4)\t-0.00833333333333\n"
        ]
       }
      ],
-     "prompt_number": 12
+     "prompt_number": 66
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "#Using the default function that returns a numpy array no sparced.\n",
+      "\n",
       "t=massmatrix(vs,5)\n",
       "print t"
      ],
@@ -176,66 +234,359 @@
        ]
       }
      ],
-     "prompt_number": 13
+     "prompt_number": 67
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "v=np.ones(nbasis)\n",
-      "v"
+      "#Using the CSC function\n",
+      "\n",
+      "t2=massmatrix(vs,5,format=\"CSC\")\n",
+      "print t2"
      ],
      "language": "python",
      "metadata": {},
      "outputs": [
       {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 14,
+       "output_type": "stream",
+       "stream": "stdout",
        "text": [
-        "array([ 1.000,  1.000,  1.000,  1.000,  1.000,  1.000,  1.000,  1.000,\n",
-        "        1.000])"
+        "  (0, 0)\t0.0333333333333\n",
+        "  (1, 0)\t0.0166666666667\n",
+        "  (2, 0)\t-0.00833333333333\n",
+        "  (0, 1)\t0.0166666666667\n",
+        "  (1, 1)\t0.133333333333\n",
+        "  (2, 1)\t0.0166666666667\n",
+        "  (0, 2)\t-0.00833333333333\n",
+        "  (1, 2)\t0.0166666666667\n",
+        "  (2, 2)\t0.0666666666667\n",
+        "  (3, 2)\t0.0166666666667\n",
+        "  (4, 2)\t-0.00833333333333\n",
+        "  (2, 3)\t0.0166666666667\n",
+        "  (3, 3)\t0.133333333333\n",
+        "  (4, 3)\t0.0166666666667\n",
+        "  (2, 4)\t-0.00833333333333\n",
+        "  (3, 4)\t0.0166666666667\n",
+        "  (4, 4)\t0.0666666666667\n",
+        "  (5, 4)\t0.0166666666667\n",
+        "  (6, 4)\t-0.00833333333333\n",
+        "  (4, 5)\t0.0166666666667\n",
+        "  (5, 5)\t0.133333333333\n",
+        "  (6, 5)\t0.0166666666667\n",
+        "  (4, 6)\t-0.00833333333333\n",
+        "  (5, 6)\t0.0166666666667\n",
+        "  (6, 6)\t0.0666666666667\n",
+        "  (7, 6)\t0.0166666666667\n",
+        "  (8, 6)\t-0.00833333333333\n",
+        "  (6, 7)\t0.0166666666667\n",
+        "  (7, 7)\t0.133333333333\n",
+        "  (8, 7)\t0.0166666666667\n",
+        "  (6, 8)\t-0.00833333333333\n",
+        "  (7, 8)\t0.0166666666667\n",
+        "  (8, 8)\t0.0333333333333\n"
        ]
       }
      ],
-     "prompt_number": 14
+     "prompt_number": 68
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "v.dot(cum.dot(v))"
+      "#Using the CSR option.\n",
+      "\n",
+      "t2=massmatrix(vs,5,format=\"CSR\")\n",
+      "print t2"
      ],
      "language": "python",
      "metadata": {},
      "outputs": [
       {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 15,
+       "output_type": "stream",
+       "stream": "stdout",
        "text": [
-        "0.99999999999999989"
+        "  (0, 0)\t0.0333333333333\n",
+        "  (0, 1)\t0.0166666666667\n",
+        "  (0, 2)\t-0.00833333333333\n",
+        "  (1, 0)\t0.0166666666667\n",
+        "  (1, 1)\t0.133333333333\n",
+        "  (1, 2)\t0.0166666666667\n",
+        "  (2, 0)\t-0.00833333333333\n",
+        "  (2, 1)\t0.0166666666667\n",
+        "  (2, 2)\t0.0666666666667\n",
+        "  (2, 3)\t0.0166666666667\n",
+        "  (2, 4)\t-0.00833333333333\n",
+        "  (3, 2)\t0.0166666666667\n",
+        "  (3, 3)\t0.133333333333\n",
+        "  (3, 4)\t0.0166666666667\n",
+        "  (4, 2)\t-0.00833333333333\n",
+        "  (4, 3)\t0.0166666666667\n",
+        "  (4, 4)\t0.0666666666667\n",
+        "  (4, 5)\t0.0166666666667\n",
+        "  (4, 6)\t-0.00833333333333\n",
+        "  (5, 4)\t0.0166666666667\n",
+        "  (5, 5)\t0.133333333333\n",
+        "  (5, 6)\t0.0166666666667\n",
+        "  (6, 4)\t-0.00833333333333\n",
+        "  (6, 5)\t0.0166666666667\n",
+        "  (6, 6)\t0.0666666666667\n",
+        "  (6, 7)\t0.0166666666667\n",
+        "  (6, 8)\t-0.00833333333333\n",
+        "  (7, 6)\t0.0166666666667\n",
+        "  (7, 7)\t0.133333333333\n",
+        "  (7, 8)\t0.0166666666667\n",
+        "  (8, 6)\t-0.00833333333333\n",
+        "  (8, 7)\t0.0166666666667\n",
+        "  (8, 8)\t0.0333333333333\n"
        ]
       }
      ],
-     "prompt_number": 15
+     "prompt_number": 69
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "    for i in range(10):\n",
+      "    for i in range(2):\n",
       "        for j in range(2,i):\n",
       "            vs=IteratedVectorSpace(UniformLagrangeVectorSpace(j), np.linspace(0,1,i))\n",
       "            v=np.ones(vs.n_dofs)\n",
       "            for k in range(2,10):\n",
-      "                t=massmatrix(vs,k)\n",
-      "                assert abs(v.dot(t.dot(v))-1.0)<10**(-10)"
+      "                tem=massmatrix(vs,k)\n",
+      "                assert abs(v.dot(tem.dot(v))-1.0)<10**(-10)"
      ],
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 28
+     "prompt_number": 70
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "#test for to decide between using LIL or DOK\n",
+      "results=[]\n",
+      "print \"cels\",\"nbasis\",\"CSR\",\"LIL\"\n",
+      "for i in np.arange(2,5):\n",
+      "    for j in np.arange(2,10):\n",
+      "        vs=IteratedVectorSpace(UniformLagrangeVectorSpace(j), np.linspace(0,1,4**i))\n",
+      "        v=np.ones(vs.n_dofs)\n",
+      "        t1 = int(round(time.time() * 1000))\n",
+      "        tdok=massmatrix(vs,3)\n",
+      "        t2 = int(round(time.time() * 1000))\n",
+      "        tlil=massmatrix(vs,3,internal=\"LIL\")\n",
+      "        t3 = int(round(time.time() * 1000))\n",
+      "        lres=[4**i, j, t2-t1,t3-t2]\n",
+      "        results.append(lres)\n",
+      "        print lres\n",
+      "print \"done\""
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "cels nbasis CSR LIL\n",
+        "[16, 2, 24, 36]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[16, 3, 56, 63]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[16, 4, 110, 92]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[16, 5, 137, 161]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[16, 6, 238, 231]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[16, 7, 330, 422]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[16, 8, 861, 1178]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[16, 9, 608, 1057]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[64, 2, 71, 69]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[64, 3, 135, 166]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[64, 4, 269, 322]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[64, 5, 657, 820]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[64, 6, 1110, 1296]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[64, 7, 1235, 1392]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[64, 8, 2424, 2709]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[64, 9, 2464, 2981]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[256, 2, 319, 390]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[256, 3, 832, 961]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[256, 4, 1136, 2423]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[256, 5, 2028, 2374]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[256, 6, 4160, 5482]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[256, 7, 5973, 7215]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[256, 8, 9414, 8595]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "[256, 9, 10149, 11687]"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "done\n"
+       ]
+      }
+     ],
+     "prompt_number": 72
     }
    ],
    "metadata": {}

--- a/tests/test_massmatix.py
+++ b/tests/test_massmatix.py
@@ -12,5 +12,9 @@ def test_massmatrix():
             for k in range(2,10):
                 t=massmatrix(vs,k)
                 assert abs(v.dot(t.dot(v))-1.0)<10**(-10)
+                csc=massmatrix(vs,k,format="CSC")
+                csr=massmatrix(vs,k,format="CSR")
+                assert (t==csc).all() and (t==csr).all()
+                
 
 test_massmatrix()

--- a/utilities/matrices.py
+++ b/utilities/matrices.py
@@ -1,6 +1,7 @@
 from interfaces.vector_space import *
 import numpy as np
 from numpy.polynomial.legendre import leggauss
+from scipy.sparse import lil_matrix, dok_matrix, csc_matrix, csr_matrix
 
 def interpolation_matrix(vs, points, d=0):
     """Compute the Interpolation Matrix associated with the given vector space
@@ -26,18 +27,24 @@ def interpolation_matrix(vs, points, d=0):
             M[ids,i] = vs.basis_der(i,d)(points[ids])
     return np.asmatrix(M)
 
-def massmatrix(vs,nq,quadfun=np.polynomial.legendre.leggauss):
+def massmatrix(vs,nq,quadfun=np.polynomial.legendre.leggauss, format="FULL", internal="DOK"):
     """A MassMatrix assembler, computing the sparse matrix 
     
     $M_{ij} =\int_0^1 v_i(x) v_j(x) dx$
-    vs: A vector_space type opject.
+    vs: A vector_space type object.
     nq: Number of quadrature points used for each individual integration.
     quadfun: a function that receives a number and returns a touple of 
                 numpy arrays with the values of quadrature points and 
                 the weights in the interval [-1;1]
+    format: output matrix format. Can be CSR, CSC or FULL (default).
+    This function returns a scipy.sparse.lil.lil_matrix that can be converted to
+    python array, ndarrays or equivalents usually with only 1 call.
+    Arithmetic operations are also supported.
+    see: http://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.sparse.lil_matrix.html
+    
     """
     (qst,wst)=quadfun(nq)
-    cum=np.zeros((vs.n_dofs,vs.n_dofs))
+    cum={"DOK":lambda : dok_matrix((vs.n_dofs,vs.n_dofs)), "LIL":lambda : lil_matrix((vs.n_dofs,vs.n_dofs))}[internal]()
     for lcell in xrange(vs.n_cells):
         a,b=vs.cells[lcell],vs.cells[lcell+1]
         q,w=((a+b)+(b-a)*qst)/2,(b-a)*wst/2
@@ -50,4 +57,7 @@ def massmatrix(vs,nq,quadfun=np.polynomial.legendre.leggauss):
         for rout, rcum in zip(out, fnts):
             for vout, ccum in zip(rout, fnts):
                 cum[rcum,ccum]+=vout
-    return cum
+                
+    fun={"FULL":lambda : cum.toarray(),"CSC":lambda : cum.tocsc(), "CSR": lambda : cum.tocsr()}
+
+    return fun[format]()


### PR DESCRIPTION
The actual function is compatible with the previous version.
The documentation was modified in the function.
The user can specify the output and the internal sparce function for to use.
In the notebook file is shown that in fact the default option (DOK) is generally faster than the alternative one (LIL)
